### PR TITLE
Stronger integration with Shiny

### DIFF
--- a/R/glify-shiny.R
+++ b/R/glify-shiny.R
@@ -92,3 +92,16 @@ renderLeafgl <- function(expr, env = parent.frame(), quoted = FALSE){
   renderLeaflet(expr = expr, env = env, quoted = quoted)
 }
 
+leafOutput <- function (outputId, width = "100%", height = 400) 
+{
+  htmlwidgets::shinyWidgetOutput(outputId, "leaflet", width, 
+                                 height, "leaflet")
+}
+
+
+leafletOutput <- function(outputId, width = "100%", height = 400){
+  tagList(
+    leafOutput(outputId = outputId, width = width, height = height),
+    tags$script(leafgl:::glifyDependencies())
+  )
+}


### PR DESCRIPTION
Most of the times Shiny communicates with leaflet via an object called proxy - it allows for interactive user changes on the map, storing "old" version of it in the memory, i.e. rendering the map from scratch is not necessary after each user's change.
The problem is that proxy object from leaflet package connects only to leafletOutput, not leafglOutput, therefore glify polygons/points/lines were not visible on proxy object - that is actual map in shiny app. 
In order to overcome that problem I modified leafletOutput object. Two functions from leaflet package will be now covered by this modification.