### PR TITLE
Add pane argument, change glLayer to layer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,6 @@
 Package: leafgl
 Type: Package
 Title: High-Performance 'WebGl' Rendering for Package 'leaflet'
-Date: 2021-09-05
 Version: 0.2.0
 Authors@R: 
     c(person(given = "Tim",

--- a/R/glify-lines.R
+++ b/R/glify-lines.R
@@ -31,6 +31,7 @@ addGlPolylines = function(map,
                           weight = 1,
                           layerId = NULL,
                           src = FALSE,
+                          pane = "overlayPane",
                           ...) {
 
   if (isTRUE(src)) {
@@ -43,6 +44,7 @@ addGlPolylines = function(map,
       , popup = popup
       , weight = weight
       , layerId = layerId
+      , pane = pane
       , ...
     )
     return(m)
@@ -132,6 +134,7 @@ addGlPolylines = function(map,
     , group
     , weight
     , layerId
+    , pane
   )
 
   leaflet::expandLimits(
@@ -139,7 +142,6 @@ addGlPolylines = function(map,
     c(bounds[2], bounds[4]),
     c(bounds[1], bounds[3])
   )
-
 }
 
 
@@ -152,6 +154,7 @@ addGlPolylinesSrc = function(map,
                              popup = NULL,
                              weight = 1,
                              layerId = NULL,
+                             pane = "overlayPane",
                              ...) {
 
   if (is.null(group)) group = deparse(substitute(data))
@@ -275,6 +278,7 @@ addGlPolylinesSrc = function(map,
     , opacity
     , group
     , layerId
+    , pane
   )
 
   leaflet::expandLimits(

--- a/R/glify-points.R
+++ b/R/glify-points.R
@@ -22,6 +22,7 @@
 #' @param layerId the layer id
 #' @param weight line width/thicknes in pixels for \code{addGlPolylines}.
 #' @param src whether to pass data to the widget via file attachments.
+#' @param pane A string which defines the pane of the layer. The default is \code{"overlayPane"}.
 #' @param ... Used to pass additional named arguments to \code{\link[jsonify]{to_json}}
 #'   & to pass additional arguments to the underlying JavaScript functions. Typical
 #'   use-cases include setting 'digits' to round the point coordinates or to pass
@@ -62,6 +63,7 @@ addGlPoints = function(map,
                        popup = NULL,
                        layerId = NULL,
                        src = FALSE,
+                       pane = "overlayPane",
                        ...) {
 
   dotopts = list(...)
@@ -76,6 +78,7 @@ addGlPoints = function(map,
       , group = group
       , popup = popup
       , layerId = layerId
+      , pane = pane
       , ...
     )
     return(m)
@@ -157,6 +160,7 @@ addGlPoints = function(map,
     , group
     , layerId
     , dotopts
+    , pane
   )
 
   leaflet::expandLimits(
@@ -164,8 +168,6 @@ addGlPoints = function(map,
     c(bounds[2], bounds[4]),
     c(bounds[1], bounds[3])
   )
-
-
 }
 
 
@@ -178,6 +180,7 @@ addGlPointsSrc = function(map,
                           group = "glpoints",
                           popup = NULL,
                           layerId = NULL,
+                          pane = "overlayPane",
                           ...) {
 
   ## currently leaflet.glify only supports single (fill)opacity!
@@ -310,6 +313,7 @@ addGlPointsSrc = function(map,
     , fillOpacity
     , group
     , layerId
+    , pane
   )
 
   leaflet::expandLimits(

--- a/R/glify-polygons.R
+++ b/R/glify-polygons.R
@@ -31,6 +31,7 @@ addGlPolygons = function(map,
                          popup = NULL,
                          layerId = NULL,
                          src = FALSE,
+                         pane = "overlayPane",
                          ...) {
 
   if (isTRUE(src)) {
@@ -43,6 +44,7 @@ addGlPolygons = function(map,
       , group = group
       , popup = popup
       , layerId = layerId
+      , pane = pane
       , ...
     )
     return(m)
@@ -119,7 +121,6 @@ addGlPolygons = function(map,
     , map$dependencies
   )
 
-
   map = leaflet::invokeMethod(
     map
     , leaflet::getMapData(map)
@@ -130,6 +131,7 @@ addGlPolygons = function(map,
     , fillOpacity
     , group
     , layerId
+    , pane
   )
 
   leaflet::expandLimits(
@@ -137,7 +139,6 @@ addGlPolygons = function(map,
     c(bounds[2], bounds[4]),
     c(bounds[1], bounds[3])
   )
-
 }
 
 
@@ -151,6 +152,7 @@ addGlPolygonsSrc = function(map,
                             group = "glpolygons",
                             popup = NULL,
                             layerId = NULL,
+                            pane = "overlayPane",
                             ...) {
 
   if (is.null(group)) group = deparse(substitute(data))
@@ -255,6 +257,7 @@ addGlPolygonsSrc = function(map,
     , fillOpacity
     , group
     , layerId
+    , pane
   )
 
   leaflet::expandLimits(

--- a/inst/htmlwidgets/Leaflet.glify/addGlifyPoints.js
+++ b/inst/htmlwidgets/Leaflet.glify/addGlifyPoints.js
@@ -1,4 +1,4 @@
-LeafletWidget.methods.addGlifyPoints = function(data, cols, popup, opacity, radius, group, layerId, dotOptions) {
+LeafletWidget.methods.addGlifyPoints = function(data, cols, popup, opacity, radius, group, layerId, dotOptions, pane) {
 
   const map = this;
 
@@ -50,7 +50,8 @@ LeafletWidget.methods.addGlifyPoints = function(data, cols, popup, opacity, radi
     color: clrs,
     opacity: opacity,
     size: rad,
-    className: group
+    className: group,
+    pane: pane
   };
 
   // extract correct fragmentShaderSource if provided via dotOptions

--- a/inst/htmlwidgets/Leaflet.glify/addGlifyPointsFl.js
+++ b/inst/htmlwidgets/Leaflet.glify/addGlifyPointsFl.js
@@ -1,4 +1,4 @@
-LeafletWidget.methods.addGlifyPointsFl = function(data_var, color_var, popup_var, opacity, size, layerId) {
+LeafletWidget.methods.addGlifyPointsFl = function(data_var, color_var, popup_var, opacity, size, layerId, pane) {
 
   var map = this;
   var data_fl = document.getElementById(data_var + '-1-attachment' ).href;
@@ -31,6 +31,7 @@ LeafletWidget.methods.addGlifyPointsFl = function(data_var, color_var, popup_var
       color: clrs,
       opacity: opacity,
       size: size,
+      pane: pane,
       // className: "test"
     });
     //map.layerManager.addLayer(test, null, null, "test");

--- a/inst/htmlwidgets/Leaflet.glify/addGlifyPointsMinimal.js
+++ b/inst/htmlwidgets/Leaflet.glify/addGlifyPointsMinimal.js
@@ -1,4 +1,4 @@
-LeafletWidget.methods.addGlifyPointsMinimal = function(data, cols, popup, opacity, size, group, layerId) {
+LeafletWidget.methods.addGlifyPointsMinimal = function(data, cols, popup, opacity, size, group, layerId, pane) {
 
   var map = this;
   //var data_fl = document.getElementById(data_var + '-1-attachment' ).href;
@@ -21,7 +21,7 @@ LeafletWidget.methods.addGlifyPointsMinimal = function(data, cols, popup, opacit
       click: function (e, point, xy) {
         var idx = data.findIndex(k => k==point);
         //set up a standalone popup (use a popup as a layer)
-        if (map.hasLayer(pointslayer.glLayer)) {
+        if (map.hasLayer(pointslayer.layer)) {
           L.popup()
             .setLatLng(point)
             .setContent(popup[idx].toString())
@@ -33,10 +33,11 @@ LeafletWidget.methods.addGlifyPointsMinimal = function(data, cols, popup, opacit
       color: clrs,
       opacity: opacity,
       size: size,
-      className: group
+      className: group,
+      pane: pane
     });
 
-  map.layerManager.addLayer(pointslayer.glLayer, "glify", layerId, group);
+  map.layerManager.addLayer(pointslayer.layer, "glify", layerId, group);
 
   //});
 

--- a/inst/htmlwidgets/Leaflet.glify/addGlifyPointsSrc.js
+++ b/inst/htmlwidgets/Leaflet.glify/addGlifyPointsSrc.js
@@ -1,4 +1,4 @@
-LeafletWidget.methods.addGlifyPointsSrc = function(fillColor, radius, fillOpacity, group, layerId) {
+LeafletWidget.methods.addGlifyPointsSrc = function(fillColor, radius, fillOpacity, group, layerId, pane) {
 
   var map = this;
 
@@ -29,7 +29,7 @@ LeafletWidget.methods.addGlifyPointsSrc = function(fillColor, radius, fillOpacit
         //var idx = data[layerId][0].indexOf(point);
         var idx = data[layerId][0].findIndex(k => k==point);
         //set up a standalone popup (use a popup as a layer)
-        if (map.hasLayer(pointslayer.glLayer)) {
+        if (map.hasLayer(pointslayer.layer)) {
           L.popup()
             .setLatLng(point)
             .setContent(popup[layerId][0][idx].toString())
@@ -41,10 +41,11 @@ LeafletWidget.methods.addGlifyPointsSrc = function(fillColor, radius, fillOpacit
     color: clrs,
     opacity: fillOpacity,
     size: size,
-    className: group
+    className: group,
+    pane: pane
   });
 
-  map.layerManager.addLayer(pointslayer.glLayer, "glify", layerId, group);
+  map.layerManager.addLayer(pointslayer.layer, "glify", layerId, group);
 
 };
 
@@ -69,7 +70,7 @@ LeafletWidget.methods.addGlifyPointsSrc2 = function(group, opacity, size, layerI
         //var idx = data[group][0].indexOf(point);
         var idx = data[group][0].findIndex(k => k==point);
         //set up a standalone popup (use a popup as a layer)
-        if (map.hasLayer(pointslayer.glLayer)) {
+        if (map.hasLayer(pointslayer.layer)) {
           L.popup()
             .setLatLng(point)
             .setContent(popup[group][0][idx].toString())
@@ -86,7 +87,7 @@ LeafletWidget.methods.addGlifyPointsSrc2 = function(group, opacity, size, layerI
       className: group
     });
 
-  map.layerManager.addLayer(pointslayer.glLayer, "glify", layerId, group);
+  map.layerManager.addLayer(pointslayer.layer, "glify", layerId, group);
 
   function add() {
         if (typeof data[grp2] === 'undefined') {
@@ -100,7 +101,7 @@ LeafletWidget.methods.addGlifyPointsSrc2 = function(group, opacity, size, layerI
                 //var idx = data[group][0].indexOf(point);
                 var idx = data[group][0].findIndex(k => k==point);
                 //set up a standalone popup (use a popup as a layer)
-                if (map.hasLayer(pointslayer.glLayer)) {
+                if (map.hasLayer(pointslayer.layer)) {
                   L.popup()
                     .setLatLng(point)
                     .setContent(popup[group][0][idx].toString())
@@ -117,7 +118,7 @@ LeafletWidget.methods.addGlifyPointsSrc2 = function(group, opacity, size, layerI
               className: group
             });
 
-           map.layerManager.addLayer(pointslayer2.glLayer, null, null, group);
+           map.layerManager.addLayer(pointslayer2.layer, "glify", null, group);
         }
     }
 

--- a/inst/htmlwidgets/Leaflet.glify/addGlifyPolygons.js
+++ b/inst/htmlwidgets/Leaflet.glify/addGlifyPolygons.js
@@ -1,4 +1,4 @@
-LeafletWidget.methods.addGlifyPolygons = function(data, cols, popup, opacity, group, layerId) {
+LeafletWidget.methods.addGlifyPolygons = function(data, cols, popup, opacity, group, layerId, pane) {
 
   var map = this;
 
@@ -63,7 +63,8 @@ LeafletWidget.methods.addGlifyPolygons = function(data, cols, popup, opacity, gr
     color: clrs,
     opacity: opacity,
     className: group,
-    border: false
+    border: false,
+    pane: pane
   });
 
   map.layerManager.addLayer(shapeslayer.layer, "glify", layerId, group);

--- a/inst/htmlwidgets/Leaflet.glify/addGlifyPolygonsFl.js
+++ b/inst/htmlwidgets/Leaflet.glify/addGlifyPolygonsFl.js
@@ -1,4 +1,4 @@
-LeafletWidget.methods.addGlifyPolygonsFl = function(data_var, color_var, popup_var, opacity) {
+LeafletWidget.methods.addGlifyPolygonsFl = function(data_var, color_var, popup_var, opacity, pane) {
 
   var map = this;
   var data_fl = document.getElementById(data_var + '-1-attachment' ).href;
@@ -38,6 +38,7 @@ LeafletWidget.methods.addGlifyPolygonsFl = function(data_var, color_var, popup_v
       color: clrs,
       opacity: opacity,
       // className: "glify-pls"
+      pane: pane
     });
   });
 

--- a/inst/htmlwidgets/Leaflet.glify/addGlifyPolygonsSrc.js
+++ b/inst/htmlwidgets/Leaflet.glify/addGlifyPolygonsSrc.js
@@ -1,4 +1,4 @@
-LeafletWidget.methods.addGlifyPolygonsSrc = function(fillColor, fillOpacity, group, layerId) {
+LeafletWidget.methods.addGlifyPolygonsSrc = function(fillColor, fillOpacity, group, layerId, pane) {
 
   var map = this;
 
@@ -20,7 +20,7 @@ LeafletWidget.methods.addGlifyPolygonsSrc = function(fillColor, fillOpacity, gro
       } else if (typeof(popup[layerId]) === "undefined") {
         return;
       } else {
-      if (map.hasLayer(shapeslayer.glLayer)) {
+      if (map.hasLayer(shapeslayer.layer)) {
           var idx = data[layerId][0].features.findIndex(k => k==feature);
           L.popup()
             .setLatLng(e.latlng)
@@ -32,9 +32,10 @@ LeafletWidget.methods.addGlifyPolygonsSrc = function(fillColor, fillOpacity, gro
     data: data[layerId][0],
     color: clrs,
     opacity: fillOpacity,
-    className: group
+    className: group,
+    pane: pane
   });
 
-  map.layerManager.addLayer(shapeslayer.glLayer, null, null, group);
+  map.layerManager.addLayer(shapeslayer.layer, "glify", null, group);
 
 };

--- a/inst/htmlwidgets/Leaflet.glify/addGlifyPolylines.js
+++ b/inst/htmlwidgets/Leaflet.glify/addGlifyPolylines.js
@@ -1,4 +1,4 @@
-LeafletWidget.methods.addGlifyPolylines = function(data, cols, popup, opacity, group, weight, layerId) {
+LeafletWidget.methods.addGlifyPolylines = function(data, cols, popup, opacity, group, weight, layerId, pane) {
 
   var map = this;
 
@@ -52,7 +52,8 @@ LeafletWidget.methods.addGlifyPolylines = function(data, cols, popup, opacity, g
     color: clrs,
     opacity: opacity,
     className: group,
-    weight: wght
+    weight: wght,
+    pane: pane
   });
 
   map.layerManager.addLayer(lineslayer.layer, "glify", layerId, group);

--- a/inst/htmlwidgets/Leaflet.glify/addGlifyPolylinesSrc.js
+++ b/inst/htmlwidgets/Leaflet.glify/addGlifyPolylinesSrc.js
@@ -1,4 +1,4 @@
-LeafletWidget.methods.addGlifyPolylinesSrc = function(color, weight, opacity, group, layerId) {
+LeafletWidget.methods.addGlifyPolylinesSrc = function(color, weight, opacity, group, layerId, pane) {
 
   var map = this;
 
@@ -26,7 +26,7 @@ LeafletWidget.methods.addGlifyPolylinesSrc = function(color, weight, opacity, gr
       } else if (typeof(popup[layerId]) === "undefined") {
         return;
       } else {
-      if (map.hasLayer(lineslayer.glLayer)) {
+      if (map.hasLayer(lineslayer.layer)) {
           var idx = data[layerId][0].features.findIndex(k => k==feature);
           L.popup()
             .setLatLng(e.latlng)
@@ -41,9 +41,10 @@ LeafletWidget.methods.addGlifyPolylinesSrc = function(color, weight, opacity, gr
     color: clrs,
     opacity: opacity,
     weight: wght,
-    className: group
+    className: group,
+    pane: pane
   });
 
-  map.layerManager.addLayer(lineslayer.glLayer, null, null, group);
+  map.layerManager.addLayer(lineslayer.layer, "glify", null, group);
 
 };

--- a/man/addGlPoints.Rd
+++ b/man/addGlPoints.Rd
@@ -17,6 +17,7 @@ addGlPolylines(
   weight = 1,
   layerId = NULL,
   src = FALSE,
+  pane = "overlayPane",
   ...
 )
 
@@ -30,6 +31,7 @@ addGlPoints(
   popup = NULL,
   layerId = NULL,
   src = FALSE,
+  pane = "overlayPane",
   ...
 )
 
@@ -43,6 +45,7 @@ addGlPolygons(
   popup = NULL,
   layerId = NULL,
   src = FALSE,
+  pane = "overlayPane",
   ...
 )
 }
@@ -69,6 +72,8 @@ match the number of rows in the dataset, the popup vector is repeated to match t
 \item{layerId}{the layer id}
 
 \item{src}{whether to pass data to the widget via file attachments.}
+
+\item{pane}{A string which defines the pane of the layer. The default is \code{"overlayPane"}.}
 
 \item{...}{Used to pass additional named arguments to \code{\link[jsonify]{to_json}}
 & to pass additional arguments to the underlying JavaScript functions. Typical


### PR DESCRIPTION
Adds the argument `pane` and should close #64 .

I also changed all the remaining `glLayer` to `layer`.

And lastly I removed the Date from the DESCRIPTION, since it is not required anymore and just throws a warning when checking.

If you approve @tim-salabim , I would merge this PR.



<details>
  <summary>Here's a little shiny-example:</summary>
  
```
library(shiny)  
library(sf)  
library(leaflet)
library(leafgl)

points <- sf::st_as_sf(breweries91)
lines <- sf::st_as_sf(leaflet::atlStorms2005)
polys = suppressWarnings(st_cast(st_as_sf(leaflet::gadmCHE), "POLYGON"))
polys = st_transform(polys, 4326)

ui <- fluidPage(leafletOutput("map"))
server <- function(input, output, session) {
  output$map <- renderLeaflet({
    leaflet() %>% 
      addTiles() %>% 
      addMapPane("webgl", zIndex = 600) %>% 
      addMapPane("webgl1", zIndex = 650) %>% 
      addMapPane("webgl2", zIndex = 700) %>% 
      addGlPolylines(
        data = lines[1:10,],
        group = "lines", 
        color = "red", 
        popup = TRUE,
        pane = "webgl") %>% 
      addGlPoints(
        data = points,
        color = "blue",
        group = "points",
        pane = "webgl1") %>% 
      addGlPolygons(
        data = polys,
        group = "polygon",
        pane = "webgl2") %>% 
      addLayersControl(overlayGroups = c("lines","points","polygon"))
    })
}
shinyApp(ui, server)
```


</details>