### PR TITLE
Add links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Authors@R:
              family = "Gatscha",
              role = "ctb",
              email = "sebastian_gatscha@gmx.at"))
-Maintainer: Tim Appelhans <tim.appelhans@gmail.com>
 Description: Provides bindings to the 'Leaflet.glify' JavaScript library which extends the 'leaflet' JavaScript library to render large data in the browser using 'WebGl'.
 License: MIT + file LICENSE
 Encoding: UTF-8
@@ -39,3 +38,5 @@ Suggests:
   colourvalues,
   shiny,
   testthat (>= 2.1.0)
+URL: https://github.com/r-spatial/leafgl
+BugReports:https://github.com/r-spatial/leafgl/issues


### PR DESCRIPTION
I see that you run the pkgdown github action, but the package has no site.

If you run `usethis::use_pkgdown_github_pages()`, it should set up quickly!

for discoverability https://blog.r-hub.io/2019/12/10/urls/